### PR TITLE
support tsunami config file

### DIFF
--- a/libs/web.go
+++ b/libs/web.go
@@ -19,12 +19,12 @@ func help(w http.ResponseWriter, r *http.Request) {
 }
 
 //Init intilize server
-func (app *App) Init(port string) {
+func (app *App) Init(endPoint string) {
 
 	app.setRoute()
 
 	app.Server = http.Server{
-		Addr:           ":" + port,
+		Addr:           endPoint,
 		Handler:        app.ServeMux,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,

--- a/worker/config-template.yaml
+++ b/worker/config-template.yaml
@@ -1,7 +1,12 @@
-name: master
-id: fed3f59d-9b32-4efe-a372-ca02d7ea9f66
+name: worker-33e116f53106
+id: 8cd50597-39df-473f-af2e-33e116f53106
+concurence: 10
+#mode "cluster" or "standalone"
+mode: cluster
 endpoints:
-  http: 127.0.0.1:8080
+  grpc: 127.0.0.1:8050
+  http: 127.0.0.1:8090
+
 
 registry:
   request_timeout: 2


### PR DESCRIPTION
support configuration file 

```
name: worker-33e116f53106
id: 8cd50597-39df-473f-af2e-33e116f53106
concurence: 10
#mode "cluster" or "standalone"
mode: cluster
endpoints:
  grpc: 127.0.0.1:8050
  http: 127.0.0.1:8090


registry:
  request_timeout: 2
  dial_timeout: 2

  #default client_config_key is  tsunami_config_client_
  #client_config_key: tsunami_config_client_
  
  #defualt endpoints is [localhost:2379, localhost:22379, localhost:32379]
  endpoints:
    - localhost:2379
    - localhost:22379
    - localhost:32379

```